### PR TITLE
Replacing `os.environ['HOME']` with `os.path.expanduser('~')` for platform independence

### DIFF
--- a/socialize/helpers/auth_helpers.py
+++ b/socialize/helpers/auth_helpers.py
@@ -3,7 +3,8 @@ import os
 
 def create_token_file(token):
     try:
-        file = open(".AUTHTOKEN",'w')
+        home_directory = os.environ['HOME']
+        file = open(os.path.join(home_directory, ".AUTHTOKEN"), 'w')
         file.write(token['token'])
         file.close()
         return(200)
@@ -13,6 +14,7 @@ def create_token_file(token):
 
 def remove_token_file():
     try:
-        os.remove(".AUTHTOKEN")
+        home_directory = os.environ['HOME']
+        os.remove(os.path.join(home_directory, ".AUTHTOKEN"))
     except:
         print('Something went wrong!')

--- a/socialize/helpers/auth_helpers.py
+++ b/socialize/helpers/auth_helpers.py
@@ -3,7 +3,7 @@ import os
 
 def create_token_file(token):
     try:
-        home_directory = os.environ['HOME']
+        home_directory = os.path.expanduser('~')
         file = open(os.path.join(home_directory, ".AUTHTOKEN"), 'w')
         file.write(token['token'])
         file.close()
@@ -14,7 +14,7 @@ def create_token_file(token):
 
 def remove_token_file():
     try:
-        home_directory = os.environ['HOME']
+        home_directory = os.path.expanduser('~')
         os.remove(os.path.join(home_directory, ".AUTHTOKEN"))
     except:
         print('Something went wrong!')

--- a/socialize/services/service.py
+++ b/socialize/services/service.py
@@ -8,9 +8,11 @@ BASE_URL = 'https://socialize.dmonn.ch/api/'
 
 class Service(object):
     def get(self, path):
-        if os.path.isfile(".AUTHTOKEN"):
+        home_directory = os.environ['HOME']
+        authtoken_file = os.path.join(home_directory, ".AUTHTOKEN")
+        if os.path.isfile(authtoken_file):
             try:
-                token = self.read_file(".AUTHTOKEN")
+                token = self.read_file(authtoken_file)
                 r = requests.get(BASE_URL + path, headers={'Authorization': 'Token ' + token})
                 return r.json()
             except Exception as e:
@@ -19,9 +21,11 @@ class Service(object):
             return self.auth_failed()
 
     def post(self, path, data):
-        if os.path.isfile(".AUTHTOKEN"):
+        home_directory = os.environ['HOME']
+        authtoken_file = os.path.join(home_directory, ".AUTHTOKEN")
+        if os.path.isfile(authtoken_file):
             try:
-                token = self.read_file(".AUTHTOKEN")
+                token = self.read_file(authtoken_file)
                 r = requests.post(BASE_URL + path, headers={'Authorization': 'Token ' + token}, data=data)
                 return r
             except Exception as e:

--- a/socialize/services/service.py
+++ b/socialize/services/service.py
@@ -8,7 +8,7 @@ BASE_URL = 'https://socialize.dmonn.ch/api/'
 
 class Service(object):
     def get(self, path):
-        home_directory = os.environ['HOME']
+        home_directory = os.path.expanduser('~')
         authtoken_file = os.path.join(home_directory, ".AUTHTOKEN")
         if os.path.isfile(authtoken_file):
             try:
@@ -21,7 +21,7 @@ class Service(object):
             return self.auth_failed()
 
     def post(self, path, data):
-        home_directory = os.environ['HOME']
+        home_directory = os.path.expanduser('~')
         authtoken_file = os.path.join(home_directory, ".AUTHTOKEN")
         if os.path.isfile(authtoken_file):
             try:


### PR DESCRIPTION
Replaced `os.environ['HOME']` with `os.path.expanduser('~')` which I believe should work properly in most platforms.